### PR TITLE
Fix #76

### DIFF
--- a/svg/achievement.inc
+++ b/svg/achievement.inc
@@ -155,8 +155,8 @@ function drawMotto($mottoNode) {
     $textLen = strlen($text);
     //adjust for long mottos
     if ($textLen > 10) {
-        $fontSize -= (2 * ($textLen - 10)); // one pixel smaller per extra letter
-        $up = ($textLen - 10) /1;
+        $fontSize -= (0.7 * ($textLen - 10)); // one pixel smaller per extra letter
+        $up = ($textLen - 10) / 1.5;
         if ($fontSize < 15) {
             $fontSize = 15; // but have a lower limit
             $up = 12;


### PR DESCRIPTION
Kinda works, might fail as we can't (easily?) calculate how much space a given string occupies (we don't have the font metrics, which in any case may vary between browser implementations). See the code changes for examples of what to tweak. Line 158 controls the font shrinkage as length increases, and 159 controls the "uppage" to keep it centered on the motto ribbon.