### PR TITLE
Take into account the flag height for inAnnulo

### DIFF
--- a/svg/arrangements.inc
+++ b/svg/arrangements.inc
@@ -98,9 +98,15 @@ function inOrle($number, $chief = false) {
 }
 
 function inAnnulo($number) {
+  global $options;
   $cx = 500;
-  $cy = 500;
-  $radius = 400;
+  if ( $options['shape'] == 'flag' )
+    $cy = $options["flagHeight"] / 2;
+  else
+    $cy = 500;
+
+  $radius = min($cy, $cx) * 0.8;
+
   $angle = 0;
   $turn = 360 / $number;
   // Make size dependent on circumference && number


### PR DESCRIPTION
Looks like "in annulo" doesn't work too well with flags. This fixes it.


Here are some example for "azure 12 mullets of 5 stars or in annulo"

Old behaviour:
![Old](https://user-images.githubusercontent.com/2465791/106435572-5bda9380-6473-11eb-839c-1745a8d72fb2.png)

Fixed:
![Fixed](https://user-images.githubusercontent.com/2465791/106435709-862c5100-6473-11eb-97d0-0d447b2445d0.png)

Also works for any flag aspect ratio, here's another example:
![Fixed ratio](https://user-images.githubusercontent.com/2465791/106435779-980df400-6473-11eb-9491-2ab8961de534.png)



