### PR TITLE
Support for customizing the palette

### DIFF
--- a/demopage.php
+++ b/demopage.php
@@ -40,6 +40,13 @@
         margin: 1em 0;
         width: 600px;
     }
+    .custom-palette {
+        display: block;
+    }
+    .custom-palette textarea {
+        width: 100%;
+        resize: horizontal;
+    }
     </style>
   </head>
 
@@ -190,6 +197,11 @@
     table_check("Tartan", "tartancols");
     echo "</div>";
 
+    echo "<div class='style-head'>Custom Palette</div>";
+    echo "<div class='style custom-palette'>";
+    echo "<textarea id='customPalette'></textarea>";
+    echo "</div>";
+
     echo "</div>";
 ?>
 
@@ -199,10 +211,10 @@
           <th colspan="2" style="border-top:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;border-bottom:0px none;">Make Printable</th>
         </tr>
         <tr>
-          <td style="text-align:center;border-left:1px solid #000000;"><img src="thumbs/other/dot-png.png" height="80px" width="80px" /></td>
-          <td style="text-align:center;"><img src="thumbs/other/dot-svg.png" height="80px" width="80px" /></td>
-          <td style="text-align:center;border-right:1px solid #000000;"><img src="thumbs/other/dot-jpg.png" height="80px" width="80px" /></td>
-          <td style="text-align:center;border-right:1px solid #000000;" colspan="2"><img src="thumbs/other/printable.png" height="80px" width="80px" /></td></td>
+          <td style="text-align:center;border-left:1px solid #000000;">PNG</td>
+          <td style="text-align:center;">SVG</td>
+          <td style="text-align:center;border-right:1px solid #000000;">JPG</td>
+          <td style="text-align:center;border-right:1px solid #000000;" colspan="2">Printable</td></td>
         </tr>
         <tr>
           <td style="text-align:center;border-left:1px solid #000000;"><input type="radio" name="format" value="png" checked="checked" /></td>
@@ -214,19 +226,6 @@
       </table>
     </form>
     <div id="resultstable"></div>
-    <div class="do-not-print align-right"><form id="quickShield">
-        <table style="width:260px;border-width:1px;border-style:solid;border-color:#050505;text-align:center">
-          <tr>
-            <td style="margin:auto;"><img id="quickImage" src="http://drawshield.net/include/shield/thumbs/other/yourshieldhere.png" width="250px" height="300px" alt="shield"/></td>
-          </tr>
-          <tr>
-            <td style="margin:auto;"><textarea id="quickBlazon" name="quickBlazon" rows="6" cols="31"></textarea></td>
-            </tr>
-          <tr>
-            <td style="margin:auto;"><input type="button" title="Update" style="width:200px" value="Draw This Shield!" onclick="quickshield('quickImage','quickBlazon');"/></td>
-          </tr>
-        </table>
-    </form></div>
     <?php $basedir = basename(getcwd()); ?>
     <script type="text/javascript" src="XMLHttpRequest.js"></script>
     <script  type="text/javascript" src="shieldcommon.js"></script>

--- a/drawshield.php
+++ b/drawshield.php
@@ -38,52 +38,34 @@ if (isset($argc)) {
 $ar = null;
 $size = null;
 // For backwards compatibility we support argument in GET, but prefer POST
-if (isset($_SERVER["REQUEST_METHOD"]) && $_SERVER["REQUEST_METHOD"] == "POST") {
-  if (isset($_FILES['blazonfile']) && ($_FILES['blazonfile']['name'] != "")) {
+if (isset($_FILES['blazonfile']) && ($_FILES['blazonfile']['name'] != "")) {
     $fileName = $_FILES['blazonfile']['name'];
     $fileSize = $_FILES['blazonfile']['size'];
     $fileTmpName  = $_FILES['blazonfile']['tmp_name'];
-   // $fileType = $_FILES['blazonfile']['type']; // not currently used
+    // $fileType = $_FILES['blazonfile']['type']; // not currently used
     if (preg_match('/.txt$/i', $fileName) && $fileSize < 1000000) {
-      $options['blazon'] = file_get_contents($fileTmpName);
-    } 
-  } else {    
-      if (isset($_POST['blazon'])) $options['blazon'] = strip_tags(trim($_POST['blazon']));
-  }
-  if (isset($_POST['outputformat'])) $options['outputFormat'] = strip_tags ($_POST['outputformat']);;
-  if (isset($_POST['saveformat'])) $options['saveFormat'] = strip_tags ($_POST['saveformat']);;
-  if (isset($_POST['asfile'])) $options['asFile'] = ($_POST['asfile'] == "1");
-  if (isset($_POST['palette'])) $options['palette'] = strip_tags($_POST['palette']);
-  if (isset($_POST['shape'])) $options['shape'] = strip_tags($_POST['shape']);
-  if (isset($_POST['stage'])) $options['stage'] = strip_tags($_POST['stage']);
-  if (isset($_POST['filename'])) $options['filename'] = strip_tags($_POST['filename']);
-//  if (isset($_POST['printable'])) $options['printable'] = ($_POST['printable'] == "1");
-  if (isset($_POST['effect'])) $options['effect'] = strip_tags($_POST['effect']);
-  if (isset($_POST['size'])) $options['size']= strip_tags ($_POST['size']);
-    if (isset($_POST['units'])) $options['units']= strip_tags ($_POST['units']);
-  if (isset($_POST['ar'])) $ar = strip_tags ($_POST['ar']);
-  if (isset($_POST['webcols'])) $options['useWebColours'] = $_POST['webcols'] == 'yes';
-  if (isset($_POST['tartancols'])) $options['useTartanColours'] = $_POST['tartancols'] == 'yes';
-  if (isset($_POST['whcols'])) $options['useWarhammerColours'] = $_POST['whcols'] == 'yes';
-} else { // for old API
-  if (isset($_GET['blazon'])) $options['blazon'] = strip_tags(trim($_GET['blazon']));
-  if (isset($_GET['saveformat'])) $options['saveFormat'] = strip_tags ($_GET['saveformat']);;
-  if (isset($_GET['outputformat'])) $options['outputFormat'] = strip_tags ($_GET['outputformat']);;
-  if (isset($_GET['asfile'])) $options['asFile'] = ($_GET['asfile'] == "1");
-  if (isset($_GET['palette'])) $options['palette'] = strip_tags($_GET['palette']);
-  if (isset($_GET['shape'])) $options['shape'] = strip_tags($_GET['shape']);
-  if (isset($_GET['stage'])) $options['stage'] = strip_tags($_GET['stage']);
-  if (isset($_GET['filename'])) $options['filename'] = strip_tags($_GET['filename']);
-  if (isset($_GET['raw'])) $options['raw'] = true;
-  //  if (isset($_GET['printable'])) $options['printable'] = ($_GET['printable'] == "1");
-  if (isset($_GET['effect'])) $options['effect'] = strip_tags($_GET['effect']);
-  if (isset($_GET['size'])) $options['size'] = strip_tags ($_GET['size']);
-    if (isset($_GET['units'])) $options['units'] = strip_tags ($_GET['units']);
-  if (isset($_GET['ar'])) $ar = strip_tags ($_GET['ar']);
-  if (isset($_GET['webcols'])) $options['useWebColours'] = true;
-  if (isset($_GET['tartancols'])) $options['useTartanColours'] = true;
-  if (isset($_GET['whcols'])) $options['useWarhammerColours'] = true;
+        $options['blazon'] = file_get_contents($fileTmpName);
+    }
+} else {
+    if (isset($_REQUEST['blazon'])) $options['blazon'] = strip_tags(trim($_REQUEST['blazon']));
 }
+
+if (isset($_REQUEST['outputformat'])) $options['outputFormat'] = strip_tags ($_REQUEST['outputformat']);;
+if (isset($_REQUEST['saveformat'])) $options['saveFormat'] = strip_tags ($_REQUEST['saveformat']);;
+if (isset($_REQUEST['asfile'])) $options['asFile'] = ($_REQUEST['asfile'] == "1");
+if (isset($_REQUEST['palette'])) $options['palette'] = strip_tags($_REQUEST['palette']);
+if (isset($_REQUEST['shape'])) $options['shape'] = strip_tags($_REQUEST['shape']);
+if (isset($_REQUEST['stage'])) $options['stage'] = strip_tags($_REQUEST['stage']);
+if (isset($_REQUEST['filename'])) $options['filename'] = strip_tags($_REQUEST['filename']);
+//  if (isset($_REQUEST['printable'])) $options['printable'] = ($_REQUEST['printable'] == "1");
+if (isset($_REQUEST['effect'])) $options['effect'] = strip_tags($_REQUEST['effect']);
+if (isset($_REQUEST['size'])) $options['size']= strip_tags ($_REQUEST['size']);
+if (isset($_REQUEST['units'])) $options['units']= strip_tags ($_REQUEST['units']);
+if (isset($_REQUEST['ar'])) $ar = strip_tags ($_REQUEST['ar']);
+if (isset($_REQUEST['webcols'])) $options['useWebColours'] = $_REQUEST['webcols'] == 'yes';
+if (isset($_REQUEST['tartancols'])) $options['useTartanColours'] = $_REQUEST['tartancols'] == 'yes';
+if (isset($_REQUEST['whcols'])) $options['useWarhammerColours'] = $_REQUEST['whcols'] == 'yes';
+if (isset($_REQUEST['customPalette']) && is_array($_REQUEST['customPalette'])) $options['customPalette'] = $_REQUEST['customPalette'];
 
 $options['blazon'] = preg_replace("/&#?[a-z0-9]{2,8};/i","",$options['blazon']); // strip all entities.
 $options['blazon'] = preg_replace("/\\x[0-9-a-f]{2}/i","",$options['blazon']); // strip all entities.

--- a/drawshield.php
+++ b/drawshield.php
@@ -37,6 +37,9 @@ if (isset($argc)) {
 // Process arguments
 $ar = null;
 $size = null;
+
+$request = array_merge($_GET, $_POST);
+
 // For backwards compatibility we support argument in GET, but prefer POST
 if (isset($_FILES['blazonfile']) && ($_FILES['blazonfile']['name'] != "")) {
     $fileName = $_FILES['blazonfile']['name'];
@@ -47,25 +50,25 @@ if (isset($_FILES['blazonfile']) && ($_FILES['blazonfile']['name'] != "")) {
         $options['blazon'] = file_get_contents($fileTmpName);
     }
 } else {
-    if (isset($_REQUEST['blazon'])) $options['blazon'] = strip_tags(trim($_REQUEST['blazon']));
+    if (isset($request['blazon'])) $options['blazon'] = strip_tags(trim($request['blazon']));
 }
 
-if (isset($_REQUEST['outputformat'])) $options['outputFormat'] = strip_tags ($_REQUEST['outputformat']);;
-if (isset($_REQUEST['saveformat'])) $options['saveFormat'] = strip_tags ($_REQUEST['saveformat']);;
-if (isset($_REQUEST['asfile'])) $options['asFile'] = ($_REQUEST['asfile'] == "1");
-if (isset($_REQUEST['palette'])) $options['palette'] = strip_tags($_REQUEST['palette']);
-if (isset($_REQUEST['shape'])) $options['shape'] = strip_tags($_REQUEST['shape']);
-if (isset($_REQUEST['stage'])) $options['stage'] = strip_tags($_REQUEST['stage']);
-if (isset($_REQUEST['filename'])) $options['filename'] = strip_tags($_REQUEST['filename']);
-//  if (isset($_REQUEST['printable'])) $options['printable'] = ($_REQUEST['printable'] == "1");
-if (isset($_REQUEST['effect'])) $options['effect'] = strip_tags($_REQUEST['effect']);
-if (isset($_REQUEST['size'])) $options['size']= strip_tags ($_REQUEST['size']);
-if (isset($_REQUEST['units'])) $options['units']= strip_tags ($_REQUEST['units']);
-if (isset($_REQUEST['ar'])) $ar = strip_tags ($_REQUEST['ar']);
-if (isset($_REQUEST['webcols'])) $options['useWebColours'] = $_REQUEST['webcols'] == 'yes';
-if (isset($_REQUEST['tartancols'])) $options['useTartanColours'] = $_REQUEST['tartancols'] == 'yes';
-if (isset($_REQUEST['whcols'])) $options['useWarhammerColours'] = $_REQUEST['whcols'] == 'yes';
-if (isset($_REQUEST['customPalette']) && is_array($_REQUEST['customPalette'])) $options['customPalette'] = $_REQUEST['customPalette'];
+if (isset($request['outputformat'])) $options['outputFormat'] = strip_tags ($request['outputformat']);;
+if (isset($request['saveformat'])) $options['saveFormat'] = strip_tags ($request['saveformat']);;
+if (isset($request['asfile'])) $options['asFile'] = ($request['asfile'] == "1");
+if (isset($request['palette'])) $options['palette'] = strip_tags($request['palette']);
+if (isset($request['shape'])) $options['shape'] = strip_tags($request['shape']);
+if (isset($request['stage'])) $options['stage'] = strip_tags($request['stage']);
+if (isset($request['filename'])) $options['filename'] = strip_tags($request['filename']);
+//  if (isset($request['printable'])) $options['printable'] = ($request['printable'] == "1");
+if (isset($request['effect'])) $options['effect'] = strip_tags($request['effect']);
+if (isset($request['size'])) $options['size']= strip_tags ($request['size']);
+if (isset($request['units'])) $options['units']= strip_tags ($request['units']);
+if (isset($request['ar'])) $ar = strip_tags ($request['ar']);
+if (isset($request['webcols'])) $options['useWebColours'] = $request['webcols'] == 'yes';
+if (isset($request['tartancols'])) $options['useTartanColours'] = $request['tartancols'] == 'yes';
+if (isset($request['whcols'])) $options['useWarhammerColours'] = $request['whcols'] == 'yes';
+if (isset($request['customPalette']) && is_array($request['customPalette'])) $options['customPalette'] = $request['customPalette'];
 
 $options['blazon'] = preg_replace("/&#?[a-z0-9]{2,8};/i","",$options['blazon']); // strip all entities.
 $options['blazon'] = preg_replace("/\\x[0-9-a-f]{2}/i","",$options['blazon']); // strip all entities.

--- a/shieldcommon.js
+++ b/shieldcommon.js
@@ -265,6 +265,17 @@ function getOptions() {
     for ( var misc of ["webcols", "whcols", "tartancols"] )
         if ( document.getElementById(misc).checked )
             options += "&" + misc;
+
+    var customPaletteArea = document.getElementById("customPalette");
+    var paletteItems = customPaletteArea.value.split("\n").map(x => x.split("=")).map(x => x.map(a => a.trim()));
+    for ( var [key, val] of paletteItems )
+    {
+        if ( key == "" || val == "" )
+            continue;
+        if ( key.search("/") == -1 )
+            key = "heraldic/" + key;
+        options += `&customPalette[${encodeURIComponent(key)}]=${encodeURIComponent(val)}`;
+    }
     return options;
 }
 

--- a/svg/tinctures.inc
+++ b/svg/tinctures.inc
@@ -51,7 +51,10 @@ function rgb($keyterm) {
         }
         if ($options['useTartanColours'] == true ) {
           $tinctures = array_merge($tinctures, readTinctureFile(__dir__ . '/schemes/tartan.txt','tartan'));
-        }        
+        }
+        if ( isset($options['customPalette']) && is_array($options['customPalette']) ) {
+            $tinctures = array_merge($tinctures, $options['customPalette']);
+        }
         if ($options['effect'] == 'inked') { // override strokes
             $tinctures['charge-stroke']='#000000';
             $tinctures['ordinary-stroke']='#000000';


### PR DESCRIPTION
This adds the ability to customize specific colors in the palette

by code:
```php
$options["customPalette"] = [
    "heraldic/azure" => "#0000ff",
    "heraldic/or" => "#ffff00"
];
```

request to drawshield.php:
```
&customPalette[heraldic%2Fazure]=%230000ff&customPalette[heraldic%2For]=%23ffff00
```

I've also simplified drawshield.php, so we don't need to handle each parameter separately for $_POST and $_GET since they are all handled the same way.