### PR TITLE
Delete zone identifier alternate data stream

### DIFF
--- a/docs/fess-plain.png:Zone.Identifier
+++ b/docs/fess-plain.png:Zone.Identifier
@@ -1,4 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=http://test.drawshield.net/create/index.html
-HostUrl=http://test.drawshield.net/include/drawshield.php


### PR DESCRIPTION
Delete an alternate data stream created when a file was downloaded from the internet and committed as a separate file with an on-Windows-unrepresentable filename, causing the repository to be un-checkout-able on Windows.