### PR TITLE
Ensure when rendered as file, image size is an integer.

### DIFF
--- a/utils/render.inc
+++ b/utils/render.inc
@@ -59,7 +59,7 @@ function convertImageFormat($sourceSVG, $targetFormat) {
         case 'jpeg':
         case 'webp':
             $imageWidth = $options['printSize'];
-            $imageHeight = $imageWidth * $proportion;
+            $imageHeight = round($imageWidth * $proportion);
             return callSharp($sourceSVG, $targetFormat, $imageWidth, $imageHeight);
         case 'png-old':   // Deprecated, will be withdrawn soon I hope
             if (file_exists("cpulimit.txt")) {


### PR DESCRIPTION
Without this calling drawshield.php to render an image can give errors:

```
Error: Expected positive integer for height but received 614.4 of type number
    at Object.invalidParameterError (/opt/bitnami/var/img-server/node_modules/sharp/lib/is.js:135:10)
    at Sharp.resize (/opt/bitnami/var/img-server/node_modules/sharp/lib/resize.js:268:16)
    at /opt/bitnami/var/img-server/img-server.js:68:10
    at Layer.handle [as handle_request] (/opt/bitnami/var/img-server/node_modules/express/lib/router/layer.js:95:5)
    at next (/opt/bitnami/var/img-server/node_modules/express/lib/router/route.js:144:13)
    at done (/opt/bitnami/var/img-server/node_modules/multer/lib/make-middleware.js:45:7)
    at indicateDone (/opt/bitnami/var/img-server/node_modules/multer/lib/make-middleware.js:49:68)
    at Multipart.<anonymous> (/opt/bitnami/var/img-server/node_modules/multer/lib/make-middleware.js:166:7)
    at Multipart.emit (node:events:514:28)
    at emitCloseNT (node:internal/streams/destroy:132:10)
```