### PR TITLE
Small fixes

### DIFF
--- a/drawshield.php
+++ b/drawshield.php
@@ -153,7 +153,7 @@ if (isset($request['whcols'])) $options['useWarhammerColours'] = $request['whcol
 if (isset($request['customPalette']) && is_array($request['customPalette'])) $options['customPalette'] = $request['customPalette'];
 
 $options['blazon'] = preg_replace("/&#?[a-z0-9]{2,8};/i","",$options['blazon']); // strip all entities.
-$options['blazon'] = preg_replace("/\\x[0-9-a-f]{2}/i","",$options['blazon']); // strip all entities.
+$options['blazon'] = preg_replace("/\\\\x[0-9-a-f]{2}/i","",$options['blazon']); // strip all entities.
 
 // Quick response for empty blazon
 if ( $options['blazon'] == '' ) {

--- a/parser/english/lexicon.inc
+++ b/parser/english/lexicon.inc
@@ -149,7 +149,7 @@ class languageDB extends lexicon
     const COMMANDS = 'commands';
  #   const DISPLACED = 'displaced';
  #
-    const LEXEMEDIR = 'parser/english/lexemes';
+    const LEXEMEDIR = __DIR__ . '/lexemes';
 
     public function __construct()
     {


### PR DESCRIPTION
Just a couple small fixes:

In newer PHP versions strings `\x12` seem to be parsed by the regex engine so it needs to be double escaped. Not sure how this behaves in older versions so it might need to be tested before merging. (Without this fix `$options['blazon']` is set to an empty string).

The English lexicon change allows for drawshield code being accessed from a different directory (i.e.: Using drawshield as a library)